### PR TITLE
fix: move late-discovered merged/closed PRs to Done

### DIFF
--- a/packages/project-board-sync/project-board-sync/src/github/api.js
+++ b/packages/project-board-sync/project-board-sync/src/github/api.js
@@ -275,6 +275,7 @@ async function getRecentItems(org, repos, monitoredUser) {
               repository { nameWithOwner }
               author { login }
               assignees(first: 5) { nodes { login } }
+              state
               updatedAt
             }
             ... on PullRequest {
@@ -283,6 +284,7 @@ async function getRecentItems(org, repos, monitoredUser) {
               repository { nameWithOwner }
               author { login }
               assignees(first: 5) { nodes { login } }
+              state
               updatedAt
             }
           }
@@ -307,6 +309,7 @@ async function getRecentItems(org, repos, monitoredUser) {
             repository { nameWithOwner }
             author { login }
             assignees(first: 5) { nodes { login } }
+            state
             updatedAt
           }
         }


### PR DESCRIPTION
### Summary
When PRs are discovered after they are already merged/closed, they were incorrectly defaulting to OPEN and being placed into Active. This change ensures they go to Done.

### Changes
- Search queries now include  for Issues and PRs so we don’t default to OPEN
- Column rules: if  is MERGED or CLOSED and not already in Done, actively set Status to Done

### Rationale
- Use the canonical  instead of juggling 
- Keep rules simple: MERGED/CLOSED → Done; otherwise existing logic applies

### Testing
- Existing tests still pass. Follow-up tests can cover late-merge scenarios in the processors layer.

### Impact
- Corrects the edge case where already-merged PRs were put into Active when first discovered
