### PR TITLE
feat(ci): 1h processing window for PR runs

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -25,6 +25,16 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Compute update window hours
+        id: compute
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "hours=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "hours=24" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install dependencies
         working-directory: packages/project-board-sync/project-board-sync
         run: npm ci
@@ -38,23 +48,12 @@ jobs:
           echo ""
           echo "Using hardcoded project URL for development"
 
-      - name: Run Project Board Sync (PR)
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
-          GITHUB_AUTHOR: ${{ github.actor }}
-          PROJECT_URL: https://github.com/orgs/bcgov/projects/16
-          UPDATE_WINDOW_HOURS: '1'
-          VERBOSE: true
-        working-directory: packages/project-board-sync/project-board-sync
-        run: npm run start
-
       - name: Run Project Board Sync
-        if: ${{ github.event_name != 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
-          GITHUB_AUTHOR: ${{ github.actor }}
+          GITHUB_AUTHOR: 'DerekRoberts'
           PROJECT_URL: https://github.com/orgs/bcgov/projects/16
+          UPDATE_WINDOW_HOURS: ${{ steps.compute.outputs.hours }}
           VERBOSE: true
         working-directory: packages/project-board-sync/project-board-sync
         run: npm run start

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -11,14 +11,17 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  GITHUB_AUTHOR_DEFAULT: DerekRoberts
+  PROJECT_URL: https://github.com/orgs/bcgov/projects/16
+  VERBOSE: true
+
 jobs:
   sync:
     concurrency:
       group: project-board-sync
       cancel-in-progress: true
     runs-on: ubuntu-latest
-    env:
-      GITHUB_AUTHOR_DEFAULT: DerekRoberts
     steps:
       - uses: actions/checkout@v4
 
@@ -44,8 +47,8 @@ jobs:
       - name: Show Project Configuration
         run: |
           echo "Project Configuration:"
-          echo "  PROJECT_URL: https://github.com/orgs/bcgov/projects/16"
-          echo "  VERBOSE: true"
+          echo "  PROJECT_URL: ${{ env.PROJECT_URL }}"
+          echo "  VERBOSE: ${{ env.VERBOSE }}"
           echo "  GITHUB_AUTHOR: ${{ env.GITHUB_AUTHOR_DEFAULT }}"
           echo ""
           echo "Using hardcoded project URL for development"
@@ -54,8 +57,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
           GITHUB_AUTHOR: ${{ env.GITHUB_AUTHOR_DEFAULT }}
-          PROJECT_URL: https://github.com/orgs/bcgov/projects/16
+          PROJECT_URL: ${{ env.PROJECT_URL }}
           UPDATE_WINDOW_HOURS: ${{ steps.compute.outputs.hours }}
-          VERBOSE: true
+          VERBOSE: ${{ env.VERBOSE }}
         working-directory: packages/project-board-sync/project-board-sync
         run: npm run start

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -17,6 +17,8 @@ jobs:
       group: project-board-sync
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    env:
+      GITHUB_AUTHOR_DEFAULT: DerekRoberts
     steps:
       - uses: actions/checkout@v4
 
@@ -44,14 +46,14 @@ jobs:
           echo "Project Configuration:"
           echo "  PROJECT_URL: https://github.com/orgs/bcgov/projects/16"
           echo "  VERBOSE: true"
-          echo "  GITHUB_AUTHOR: ${{ github.actor }}"
+          echo "  GITHUB_AUTHOR: ${{ env.GITHUB_AUTHOR_DEFAULT }}"
           echo ""
           echo "Using hardcoded project URL for development"
 
       - name: Run Project Board Sync
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
-          GITHUB_AUTHOR: 'DerekRoberts'
+          GITHUB_AUTHOR: ${{ env.GITHUB_AUTHOR_DEFAULT }}
           PROJECT_URL: https://github.com/orgs/bcgov/projects/16
           UPDATE_WINDOW_HOURS: ${{ steps.compute.outputs.hours }}
           VERBOSE: true

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -38,7 +38,19 @@ jobs:
           echo ""
           echo "Using hardcoded project URL for development"
 
+      - name: Run Project Board Sync (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
+          GITHUB_AUTHOR: ${{ github.actor }}
+          PROJECT_URL: https://github.com/orgs/bcgov/projects/16
+          UPDATE_WINDOW_HOURS: '1'
+          VERBOSE: true
+        working-directory: packages/project-board-sync/project-board-sync
+        run: npm run start
+
       - name: Run Project Board Sync
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
           GITHUB_AUTHOR: ${{ github.actor }}


### PR DESCRIPTION
Summary: Reduce API usage during PR checks by setting UPDATE_WINDOW_HOURS=1 only for pull_request runs. Changes: Workflow-only; no action code changes. Impact: PR runs make fewer API calls; scheduled/dispatch remain at 24h unless overridden.