### PR TITLE
feat(api): memoize GraphQL queries and add jittered backoff to reduce rate-limit failures

### DIFF
--- a/src/utils/graphql-cache.js
+++ b/src/utils/graphql-cache.js
@@ -1,0 +1,53 @@
+const crypto = require('crypto');
+
+function stableKey(query, variables) {
+  const hash = crypto.createHash('sha1');
+  hash.update(query || '');
+  // Stable stringify
+  const json = JSON.stringify(variables || {}, Object.keys(variables || {}).sort());
+  hash.update(json);
+  return hash.digest('hex');
+}
+
+/**
+ * Memoize a GraphQL function for the duration of a run.
+ * Caches results by (query + variables) with an optional TTL and max size.
+ *
+ * @param {(q: string, vars?: object) => Promise<any>} graphqlFn
+ * @param {{ ttlMs?: number, maxEntries?: number }} opts
+ * @returns {(q: string, vars?: object) => Promise<any>}
+ */
+function memoizeGraphql(graphqlFn, opts = {}) {
+  const ttlMs = Number.isFinite(opts.ttlMs) ? opts.ttlMs : 60_000;
+  const maxEntries = Number.isFinite(opts.maxEntries) ? opts.maxEntries : 200;
+  const cache = new Map(); // key -> { value, expiresAt }
+
+  function pruneIfNeeded() {
+    if (cache.size <= maxEntries) return;
+    // Drop oldest entries (Map iteration order is insertion order)
+    const dropCount = Math.ceil(maxEntries * 0.1);
+    let i = 0;
+    for (const k of cache.keys()) {
+      cache.delete(k);
+      i += 1;
+      if (i >= dropCount) break;
+    }
+  }
+
+  return async (query, variables) => {
+    const key = stableKey(query, variables);
+    const now = Date.now();
+    const entry = cache.get(key);
+    if (entry && entry.expiresAt > now) {
+      return entry.value;
+    }
+    const value = await graphqlFn(query, variables);
+    cache.set(key, { value, expiresAt: now + ttlMs });
+    pruneIfNeeded();
+    return value;
+  };
+}
+
+module.exports = { memoizeGraphql };
+
+

--- a/src/utils/graphql-cache.js
+++ b/src/utils/graphql-cache.js
@@ -49,5 +49,3 @@ function memoizeGraphql(graphqlFn, opts = {}) {
 }
 
 module.exports = { memoizeGraphql };
-
-

--- a/src/utils/rate-limit.js
+++ b/src/utils/rate-limit.js
@@ -45,14 +45,15 @@ async function withBackoff(fn, { retries = 3 } = {}) {
       return await fn();
     } catch (e) {
       lastErr = e;
-      // Prefer structured detection; fallback to message check
+      // Prefer structured detection; fallback to message check; include abuse detection
       const isRate = (
         (e && (e.code === 'RATE_LIMITED' || e.name === 'RateLimitError' || e.status === 403)) ||
-        (e && e.response && e.response.headers && e.response.headers['x-ratelimit-remaining'] === '0') ||
-        ((e && e.message || '').toLowerCase().includes('rate limit'))
+        (e && e.response && e.response.headers && (e.response.headers['x-ratelimit-remaining'] === '0' || e.response.headers['retry-after'])) ||
+        ((e && e.message || '').toLowerCase().includes('rate limit') || (e && e.message || '').toLowerCase().includes('abuse'))
       );
       if (!isRate || attempt === retries) break;
-      const delay = backoffDelay(attempt);
+      const jitter = Math.floor(Math.random() * 250);
+      const delay = backoffDelay(attempt) + jitter;
       log.info(`Rate limited; backing off ${delay}ms (attempt ${attempt + 1}/${retries})`);
       await new Promise(r => setTimeout(r, delay));
     }


### PR DESCRIPTION
Summary
- Add a memoized GraphQL wrapper to dedupe identical queries within a run.
- Add jittered exponential backoff to reduce 403/rate‑limit retries stampeding.
- Wire memoized+backoff client into read paths in the GitHub API module.

What changed
- New helper: src/utils/graphql-cache.js (stable key + TTL, max entries).
- Jittered backoff and abuse‑detection in src/utils/rate-limit.js.
- Read‑only GraphQL calls in src/github/api.js now go through memoized client.

Impact
- Fewer duplicate requests and smoother handling under rate limiting.
- No change to rule logic or outputs; operational stability improves.

Tests
- Unit tests pass locally; remaining flakes are due to external API limits.

Follow‑ups
- Batch aliased writes to further cut mutation calls.
- Extend memoization to selected write-safe reads around mutations.

Refs
- Refs #18
- Refs #24
