### PR TITLE
fix(sprints): preserve history for Done items using completion date

### DIFF
--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -85,17 +85,8 @@ Default organization:
 
 ## Review Comment Triage
 
-We address every review comment explicitly using one of three outcomes and respond inline on the PR:
+For the Accept / Defer / Dismiss policy and templates, see the shared organization guide:
 
-- Accept: Implement in this PR. Criteria: correctness, reduced duplication, clearer intent, safer behavior, reduced API usage, or aligns with conventions. Include a short rationale and the follow-up commit hash.
-- Defer: Schedule for a later PR. Criteria: non-trivial design, significant scope increase, unrelated to current PR, or requires tests/infra not included. Respond with why it’s out-of-scope and when/where it will be handled (e.g., tracking issue/PR).
-- Dismiss: Do not implement. Criteria: purely stylistic churn, reduces clarity, conflicts with conventions, or adds risk without clear benefit. Provide a brief, respectful rationale and invite re-open if context changes.
+- copilot-upstream: `.github/copilot-upstream.md` (single source of truth)
 
-Reply templates (suggested):
-- Accept: “Accept — Improves X without behavior change; implemented in <commit>.”
-- Defer: “Defer — Out of scope for this PR, tracked in <issue/PR>; will address after <dependency>.”
-- Dismiss: “Dismiss — Conflicts with <convention/constraint> or adds churn without benefit; happy to revisit with more context.”
-
-Scope guardrails:
-- Prefer focused PRs; avoid mixing refactors with behavioral changes unless necessary.
-- If addressing a comment substantially broadens scope, choose Defer and document the follow-up.
+This repository follows that policy verbatim. If the upstream policy changes, this repo inherits it automatically.

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -82,3 +82,20 @@ Default organization:
 - Update window: 24 hours (based on item update time)
 - API quota management: Automatically adapts to limits
 - Caching: Optimizes frequent data access
+
+## Review Comment Triage
+
+We address every review comment explicitly using one of three outcomes and respond inline on the PR:
+
+- Accept: Implement in this PR. Criteria: correctness, reduced duplication, clearer intent, safer behavior, reduced API usage, or aligns with conventions. Include a short rationale and the follow-up commit hash.
+- Defer: Schedule for a later PR. Criteria: non-trivial design, significant scope increase, unrelated to current PR, or requires tests/infra not included. Respond with why it’s out-of-scope and when/where it will be handled (e.g., tracking issue/PR).
+- Dismiss: Do not implement. Criteria: purely stylistic churn, reduces clarity, conflicts with conventions, or adds risk without clear benefit. Provide a brief, respectful rationale and invite re-open if context changes.
+
+Reply templates (suggested):
+- Accept: “Accept — Improves X without behavior change; implemented in <commit>.”
+- Defer: “Defer — Out of scope for this PR, tracked in <issue/PR>; will address after <dependency>.”
+- Dismiss: “Dismiss — Conflicts with <convention/constraint> or adds churn without benefit; happy to revisit with more context.”
+
+Scope guardrails:
+- Prefer focused PRs; avoid mixing refactors with behavioral changes unless necessary.
+- If addressing a comment substantially broadens scope, choose Defer and document the follow-up.


### PR DESCRIPTION
fix(sprints): preserve history for Done items using completion date

- Read Sprint field reliably by field ID instead of first field value.
- Add helpers: getSprintIterations, findSprintForDate, getItemCompletionDate.
- For Done: assign sprint that contains mergedAt/closedAt; if missing/unmapped, error instead of defaulting to current.
- For Active/Next/Waiting: unchanged (assign active sprint with no-op guard).

Impact
- Prevents historical items from being bucketed into the current sprint.
- Corrects existing misassignments during the next sweep.

Ref
- Example of affected item: bcgov/nr-fom#742
