### PR TITLE
feat: enforce rules.yml column transitions

### DIFF
--- a/src/utils/state-verifier.js
+++ b/src/utils/state-verifier.js
@@ -98,6 +98,11 @@ class StateVerifier {
       validateRequired(rules, 'rules');
       this.steps.validateStepCompleted('TRANSITION_VALIDATOR_CONFIGURED');
 
+      // Reset validator instance so we load a fresh rule set each time
+      if (this.transitionValidator) {
+        this.transitionValidator = null;
+      }
+
       if (!rules.rules || !rules.rules.columns) return;
 
       // Mark required steps as complete before adding transition rules

--- a/test/state-verifier-transitions.test.js
+++ b/test/state-verifier-transitions.test.js
@@ -1,0 +1,79 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { StateVerifier } = require('../src/utils/state-verifier');
+
+function resetStateVerifier() {
+  StateVerifier.transitionValidator = null;
+  if (StateVerifier.steps?.completedSteps) {
+    StateVerifier.steps.completedSteps.clear();
+  }
+}
+
+function buildRules(transitions) {
+  return {
+    rules: {
+      columns: [
+        {
+          name: 'test_rule',
+          validTransitions: transitions
+        }
+      ]
+    }
+  };
+}
+
+test('StateVerifier.initializeTransitionRules loads validTransitions and enforces them', () => {
+  resetStateVerifier();
+  // Prime the validator to satisfy dependency checks
+  StateVerifier.getTransitionValidator();
+
+  StateVerifier.initializeTransitionRules(
+    buildRules([
+      { from: 'New', to: 'Active', conditions: [] },
+      { from: 'None', to: 'Active', conditions: [] }
+    ])
+  );
+
+  const validator = StateVerifier.getTransitionValidator();
+  const allowed = validator.validateColumnTransition('New', 'Active');
+  assert.equal(allowed.valid, true, 'Transition declared in rules should be allowed');
+
+  const disallowed = validator.validateColumnTransition('Active', 'New');
+  assert.equal(disallowed.valid, false, 'Undeclared transition should be blocked');
+  assert.equal(
+    disallowed.reason,
+    'Transition from "Active" to "New" is not allowed',
+    'Blocked transition should provide clear reason'
+  );
+});
+
+test('StateVerifier.initializeTransitionRules replaces previously loaded transitions', () => {
+  resetStateVerifier();
+  StateVerifier.getTransitionValidator();
+
+  StateVerifier.initializeTransitionRules(
+    buildRules([{ from: 'New', to: 'Active', conditions: [] }])
+  );
+  let validator = StateVerifier.getTransitionValidator();
+  assert.equal(
+    validator.validateColumnTransition('New', 'Active').valid,
+    true,
+    'Initial transition should be allowed'
+  );
+
+  StateVerifier.initializeTransitionRules(
+    buildRules([{ from: 'New', to: 'Review', conditions: [] }])
+  );
+  validator = StateVerifier.getTransitionValidator();
+  assert.equal(
+    validator.validateColumnTransition('New', 'Active').valid,
+    false,
+    'Old transitions should be cleared on re-initialization'
+  );
+  assert.equal(
+    validator.validateColumnTransition('New', 'Review').valid,
+    true,
+    'Newly declared transition should be allowed'
+  );
+});
+


### PR DESCRIPTION
## Summary
- refresh state verifier to rebuild transition validator each time rules are loaded
- load validTransitions from rules.yml into a fresh validator instance to avoid stale rules
- add focused tests ensuring valid transitions are enforced and stale transitions are cleared

## Testing
- node --test *(fails: legacy CommonJS suites still rely on require under ESM; pre-existing issue)*