### PR TITLE
docs: refresh code-to-rules mapping

### DIFF
--- a/specs/001-re-engineer-project-board-automator/code-to-rules-mapping.md
+++ b/specs/001-re-engineer-project-board-automator/code-to-rules-mapping.md
@@ -274,8 +274,8 @@ Each section maps:
 - **Function**: `processAssignees()`
 - **Rule Processing**: Uses `processAssigneeRules()` from unified processor
 - **Action Execution**: `setItemAssignees()` in `assignees.js`
-  - Resolves repository assignee roster via `fetchRepoAssignees()` (`src/github/api.js`)
-  - Translates GitHub logins to node IDs with `getUserIdsBatched()` for minimal diff updates
+  - Resolves repository assignee roster via `fetchRepoAssignees()` (`src/rules/assignees.js`)
+  - Translates GitHub logins to node IDs with `getUserIdsBatched()` (`src/rules/assignees.js`) for minimal diff updates
   - Covered by `test/rules/assignees-delta.test.js`
 
 **Implementation Details**:


### PR DESCRIPTION
## Summary
- document event payload seeding path and cached project item updates
- update column and sprint sections to reflect strict transition enforcement, batching, and removal support
- map new tests and API helpers to their corresponding rules, leaving linked-issue work as the remaining gap

## Testing
- n/a (documentation only)