### PR TITLE
fix: handle cross-org repos in search queries and add backfill mode

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -5,6 +5,12 @@ on:
   schedule:
     - cron: "0 10 * * *" # daily at 02:00 PT / 10:00 UTC
   workflow_dispatch:
+    inputs:
+      backfill:
+        description: 'Backfill: discover all items without date filter (one-time use for initial population)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -63,6 +69,7 @@ jobs:
           echo "  PROJECT_URL: ${{ env.PROJECT_URL }}"
           echo "  VERBOSE: ${{ env.VERBOSE }}"
           echo "  GITHUB_AUTHOR: ${{ env.GITHUB_AUTHOR_DEFAULT }}"
+          echo "  BACKFILL: ${{ github.event.inputs.backfill || 'false' }}"
           echo ""
           echo "Workflow Context:"
           echo "  Event: ${{ github.event_name }}"
@@ -80,4 +87,5 @@ jobs:
           UPDATE_WINDOW_HOURS: ${{ steps.compute.outputs.hours }}
           VERBOSE: ${{ env.VERBOSE }}
           CONFIG_FILE: ${{ env.CONFIG_FILE }}
+          BACKFILL: ${{ github.event.inputs.backfill }}
         run: npm run start

--- a/specs/002-cross-org-repo-search/spec.md
+++ b/specs/002-cross-org-repo-search/spec.md
@@ -1,0 +1,105 @@
+# Fix: Cross-Org Repo Search and Backfill Mode
+
+## Problem Statement
+
+Items from repositories in organizations other than the default (`bcgov`) were never discovered by the automation. For example, `bcgov-c/nr-mof-db` had ~130 issues/PRs assigned to a monitored user, but only 7 (added manually) were on the project board. None received automatic sprint assignments.
+
+**Root Causes:**
+1. **Malformed repo search queries**: The code constructed `repo:bcgov/bcgov-c/nr-mof-db` instead of `repo:bcgov-c/nr-mof-db`. The `rules.yml` stores repos as fully qualified names (`bcgov-c/nr-mof-db`), but `getRecentItems` unconditionally prefixed them with the default org (`bcgov/`). Confirmed via GraphQL: the correct query returns 71 results, the malformed one returns 0.
+2. **No backfill mechanism**: All search queries used `created:>since` with a 24-hour window. Only items created in the last 24 hours were ever discovered. Items created before the automation was deployed were permanently invisible.
+
+**Impact:**
+- Cross-org repositories (e.g. `bcgov-c/*`) were effectively excluded from automation
+- Items from those repos never appeared on the board or received sprint assignments
+- No way to populate the board with pre-existing items
+
+## Solution
+
+### 1. Handle Fully Qualified Repo Names
+
+Repos that already contain an org prefix (e.g. `bcgov-c/nr-mof-db`) are used directly in search queries instead of being prefixed with the default org.
+
+**Applied in three locations:**
+- `src/github/api.js`: repo search query construction
+- `src/rules/add-items.js`: `monitoredRepos` set construction
+- `src/index.js`: log output
+
+**Pattern:**
+```javascript
+// Before (broken for cross-org repos)
+`repo:${org}/${repo}`
+
+// After
+repo.includes('/') ? repo : `${org}/${repo}`
+```
+
+### 2. Backfill Mode
+
+A `BACKFILL` environment variable (exposed as a `workflow_dispatch` input) removes the `created:>since` date filter from all three search queries, allowing discovery of all items regardless of creation date.
+
+**Usage**: Actions → GH Project Board Sync → Run workflow → check "Backfill"
+
+This is intended for one-time use during initial board population. Normal scheduled runs use the 24-hour window.
+
+## Implementation Details
+
+### Search Query Construction
+
+`getRecentItems` in `src/github/api.js` builds three search queries:
+1. **Repo search**: `repo:org/repo created:>since` — now handles `repo:org1/repo1 OR repo:org2/repo2` correctly
+2. **Author search**: `org:bcgov org:bcgov-c author:user created:>since`
+3. **Assignee search**: `org:bcgov org:bcgov-c assignee:user created:>since`
+
+When `BACKFILL=true`, the `created:>since` clause is omitted from all three.
+
+### Rule Processing
+
+No changes to rule processing. The fix is entirely in the search/discovery layer. Once items are found, they follow the existing pipeline: board addition → column assignment → sprint assignment → assignees → linked issues.
+
+## Test Scenarios
+
+### Acceptance Criteria
+
+1. ✅ Cross-org repos (`bcgov-c/nr-mof-db`) produce correct search queries
+2. ✅ Same-org repos (`bcgov/nr-nerds`) still work correctly
+3. ✅ Backfill mode discovers items regardless of creation date
+4. ✅ Normal mode still uses 24-hour window
+5. ✅ All existing tests pass (53/53)
+
+### Test Cases
+
+**Scenario 1: Cross-org repo search**
+- Repo `bcgov-c/nr-mof-db` in `rules.yml` repositories list
+- Expected: query is `repo:bcgov-c/nr-mof-db`, not `repo:bcgov/bcgov-c/nr-mof-db`
+
+**Scenario 2: Same-org repo still works**
+- Repo `bcgov/nr-nerds` in repositories list
+- Expected: query is `repo:bcgov/nr-nerds` (unchanged behavior)
+
+**Scenario 3: Partial repo name**
+- Repo `nr-nerds` (no org prefix) in repositories list
+- Expected: query is `repo:bcgov/nr-nerds` (org prepended as before)
+
+**Scenario 4: Backfill mode**
+- `BACKFILL=true` set
+- Expected: no `created:>since` in any search query
+
+## Related Code
+
+### Files Modified
+
+- `src/github/api.js`: Handle fully qualified repo names in search queries; add BACKFILL env var support
+- `src/rules/add-items.js`: Fix `monitoredRepos` set construction for cross-org repos
+- `src/index.js`: Fix log output for cross-org repo names
+- `.github/workflows/project-board-sync.yml`: Add `backfill` workflow_dispatch input
+
+### Related Pull Request
+
+- PR #150: fix: handle cross-org repos in search queries and add backfill mode
+  - Link: https://github.com/bcgov/action-gh-project-automator/pull/150
+
+## References
+
+- Spec template: `specs/templates/spec-template.md`
+- Related spec: `specs/001-issues-assigned-to-users/spec.md`
+- Rules.yml documentation: See root `rules.yml` file

--- a/src/github/api.js
+++ b/src/github/api.js
@@ -372,7 +372,14 @@ async function getRecentItems(org, repos, monitoredUser, windowHours = undefined
   if (!Number.isFinite(hours) || hours <= 0) {
     hours = Number.isFinite(windowHours) && windowHours > 0 ? windowHours : 24;
   }
-  const since = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+  // Backfill mode: skip date filter to discover all existing items
+  const backfill = process.env.BACKFILL === 'true';
+  const sinceClause = backfill ? '' : ` created:>${new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()}`;
+
+  if (backfill) {
+    logger.info('🔄 BACKFILL mode enabled — searching all items without date filter');
+  }
 
   const rateStatus = await shouldProceedFn(minRemaining);
   if (!rateStatus.proceed) {
@@ -382,20 +389,24 @@ async function getRecentItems(org, repos, monitoredUser, windowHours = undefined
   }
 
   // Search for items in monitored repositories
-  const repoQueries = repos.map(repo => `repo:${org}/${repo} created:>${since}`);
+  // Repos may be fully qualified (org/repo) or partial (repo under default org)
+  const repoQueries = repos.map(repo => {
+    const qualifiedName = repo.includes('/') ? repo : `${org}/${repo}`;
+    return `repo:${qualifiedName}${sinceClause}`;
+  });
   const repoSearchQuery = repoQueries.join(' ');
 
   // Search for PRs authored by monitored user in allowed organizations only
   const authorOrgsQuery = allowedOrgs.map(o => `org:${o}`).join(' ');
-  const authorSearchQuery = authorOrgsQuery 
-    ? `${authorOrgsQuery} author:${monitoredUser} created:>${since}`
-    : `author:${monitoredUser} created:>${since}`;
-  
+  const authorSearchQuery = authorOrgsQuery
+    ? `${authorOrgsQuery} author:${monitoredUser}${sinceClause}`
+    : `author:${monitoredUser}${sinceClause}`;
+
   // Search for issues/PRs assigned to monitored user in allowed organizations only
   const assigneeOrgsQuery = allowedOrgs.map(o => `org:${o}`).join(' ');
   const assigneeSearchQuery = assigneeOrgsQuery
-    ? `${assigneeOrgsQuery} assignee:${monitoredUser} created:>${since}`
-    : `assignee:${monitoredUser} created:>${since}`;
+    ? `${assigneeOrgsQuery} assignee:${monitoredUser}${sinceClause}`
+    : `assignee:${monitoredUser}${sinceClause}`;
 
   logger.info(`User-scoped search limited to orgs: ${allowedOrgs.join(', ') || 'all'}`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -229,7 +229,7 @@ async function main() {
       log.info('State tracking enabled');
     }
     const startTime = new Date();
-    log.info('Monitored Repos: ' + context.repos.map(r => `${context.org}/${r}`).join(', '));
+    log.info('Monitored Repos: ' + context.repos.map(r => r.includes('/') ? r : `${context.org}/${r}`).join(', '));
 
     // Determine tighter search window (1h) in PR context unless overridden via env
     const windowHours = process.env.GITHUB_EVENT_NAME === 'pull_request'

--- a/src/rules/add-items.js
+++ b/src/rules/add-items.js
@@ -47,7 +47,7 @@ async function processAddItems({ org, repos, monitoredUser, projectId, windowHou
 
   const addedItems = [];
   const skippedItems = [];
-  const monitoredRepos = new Set(repos.map(repo => `${org}/${repo}`));
+  const monitoredRepos = new Set(repos.map(repo => repo.includes('/') ? repo : `${org}/${repo}`));
   logger.info(`📋 Monitoring repositories:\n${[ ...monitoredRepos ].map(r => `  • ${r}`).join('\n')}\n`, true);
 
   for (const item of uniqueItems) {


### PR DESCRIPTION
## Summary

- Fix repo search query construction for repositories in different organizations (e.g. `bcgov-c/nr-mof-db`). Queries were malformed as `repo:bcgov/bcgov-c/nr-mof-db` instead of `repo:bcgov-c/nr-mof-db`, causing 0 items to be found from cross-org repos.
- Add `BACKFILL` mode (via `workflow_dispatch` input) that removes the `created:>since` date filter, allowing one-time discovery of all existing items from monitored repositories.

## Root Cause

The code constructed all repo search queries as `repo:${defaultOrg}/${repoName}`, but `rules.yml` stores repos as fully qualified names (`bcgov-c/nr-mof-db`). This produced `repo:bcgov/bcgov-c/nr-mof-db` — a broken query returning 0 results. Confirmed via GraphQL: the correct query `repo:bcgov-c/nr-mof-db` returns 71 results, the malformed one returns 0.

Additionally, all search queries used `created:>since` with a 24-hour window, meaning only items created in the last 24 hours were ever discovered. Items created before the automation was deployed were invisible.

## Changes

| File | Fix |
|------|-----|
| `src/github/api.js` | Handle fully qualified repo names; add `BACKFILL` env var support |
| `src/rules/add-items.js` | Fix `monitoredRepos` set construction for cross-org repos |
| `src/index.js` | Fix logging for cross-org repo names |
| `.github/workflows/project-board-sync.yml` | Add `backfill` workflow_dispatch input |

## Usage

After merging, trigger a one-time backfill via **Actions → GH Project Board Sync → Run workflow → check "Backfill"**. This will discover and add all existing items from monitored repos to the project board with proper column and sprint assignments.