### PR TITLE
chore: upgrade to Node 24 runtime

### DIFF
--- a/.github/actions/sync-engine/action.yml
+++ b/.github/actions/sync-engine/action.yml
@@ -30,5 +30,5 @@ inputs:
     default: 'rules.yml'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../../../dist/index.js'

--- a/.github/workflows/pr-sync.yml
+++ b/.github/workflows/pr-sync.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - name: Run Tests
         shell: bash
         run: |

--- a/.github/workflows/schedule-sync.yml
+++ b/.github/workflows/schedule-sync.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - name: Run Tests
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚀 Project Sync
 
-[![Node.js 20+](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
+[![Node.js 24+](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![ES Modules](https://img.shields.io/badge/module-ESM-blue.svg)](https://nodejs.org/api/esm.html)
 [![Checks](https://img.shields.io/badge/Stability-Ludicrous%20Coverage-orange.svg)](#stability--predictability)
 
@@ -21,7 +21,7 @@ This tool transforms your GitHub Project into a self-driving productivity engine
 We treat stability as a first-class feature. Our "Ludicrous Testing" philosophy ensures that every rule processed is verified against a comprehensive matrix of conditions.
 
 - **Hardcoded Validation**: We use a strict whitelist-based validator to ensure rule evaluation is 100% predictable and secure against code injection.
-- **Native Efficiency**: Built on **Node.js 20** and native **ES Modules** for lightning-fast, future-proof execution.
+- **Native Efficiency**: Built on **Node.js 24** and native **ES Modules** for lightning-fast, future-proof execution.
 - **Zero-Network Tests**: Our 240+ count test suite runs in pure isolation, guaranteeing that the core logic is bulletproof without ever making a real API call.
 - **Strict Environments**: We enforce Node versions via `.npmrc` to ensure that every developer and CI runner is perfectly aligned.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "type": "module",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "validate": "node scripts/validate.js",


### PR DESCRIPTION
This PR finalize the modernization by upgrading the action runtime, package engines, and CI workflows to Node 24. This silences the deprecation warnings appearing in the runner logs. Closes #158