### PR TITLE
fix: assign sprints to closed PRs

### DIFF
--- a/rules.yml
+++ b/rules.yml
@@ -62,6 +62,7 @@ automation:
       - bcgov/actions
       - bcgov/action-builder-ghcr
       - bcgov/action-crunchy
+      - bcgov/action-deployer-openshift
       - bcgov/action-gh-project-automator
       - bcgov/copilot-instructions
       - bcgov/nr-nerds

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ async function run() {
         }
 
         // --- Sprint Assignment ---
-        const activeColumns = ['Active', 'Next', 'Waiting'];
+        const activeColumns = ['Active', 'Next', 'Waiting', 'Done'];
         const inactiveColumns = ['New', 'Parked', 'Backlog'];
 
         const finalColumn = targetColumn || currentColumn;


### PR DESCRIPTION
Fixes a bug where authored PRs from allowed orgs were ignored for sprint assignment when they closed/merged and moved to the Done column.