### PR TITLE
docs: authentication and token setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ project:
     - bcgov-nr
 ```
 
+### Authentication & Token Setup
+
+The sync engine requires authentication via a repository secret named `PROJECT_SYNC_TOKEN` configured in your workflow (`.github/workflows/sync.yml`).
+
+#### Token Options & Required Scopes
+
+| Authentication Option | Required Scopes / Permissions | Best Used When |
+| :--- | :--- | :--- |
+| **Classic PAT (Private Repos)** | • `repo` (Full control of private repositories)<br>• `project` (Full control of org & user projects)<br>• `read:org` (Read org membership under `admin:org`) | Monitoring private repositories (e.g., `bcgov-c`). *Note: GitHub automatically locks child sub-scopes when `repo` is checked.* |
+| **Classic PAT (Public Repos Only)** | • `public_repo`<br>• `project`<br>• `read:org` | Monitoring public repositories only (`bcgov`). Private orgs like `bcgov-c` must be removed from `rules.yml`. |
+| **Fine-Grained PAT / GitHub App** | • **Issues**: `Read & write`<br>• **Pull requests**: `Read & write`<br>• **Projects**: `Read & write` | Enterprise setups avoiding `security_events` entirely. Requires organization admin enablement or GitHub App installation. |
+
+#### Adding the Secret to GitHub Actions
+
+1. Generate your token in GitHub **Settings** → **Developer Settings** → **Personal Access Tokens**.
+2. Navigate to your repository's **Settings** → **Secrets and variables** → **Actions**.
+3. Click **New repository secret**.
+4. Set **Name** to `PROJECT_SYNC_TOKEN` and paste your token in **Secret**.
+
 ## Development & Specs
 
 This project follows a **Spec-Driven Development** model using the [SpecKit](https://github.com/github/spec-kit) framework.

--- a/README.md
+++ b/README.md
@@ -86,34 +86,25 @@ project:
 
 The sync engine requires authentication via a repository secret named `PROJECT_SYNC_TOKEN` configured in your workflow (`.github/workflows/sync.yml`).
 
-#### Recommended: Fine-Grained Personal Access Token (PAT)
+#### Fine-Grained Personal Access Token Setup (Least Privilege)
 
-Fine-Grained PATs provide least-privilege security and avoid broad scopes like `security_events`, `repo:invite`, or `repo_deployment`.
-
-1. Go to GitHub **Settings** → **Developer Settings** → **Personal Access Tokens** → **Fine-grained tokens**.
+1. Go to GitHub **Settings** → **Developer Settings** → **Personal Access Tokens** → [**Fine-grained tokens**](https://github.com/settings/tokens?type=beta).
 2. Click **Generate new token**.
-3. Set **Resource Owner** to `bcgov` (or your account with access to monitored repos).
-4. Under **Repository Access**, select **All repositories** (or select the specific repos in `bcgov`, `bcgov-c`, `bcgov-nr`).
-5. Configure permissions:
+3. Set **Token Name** to `PROJECT_SYNC_TOKEN`.
+4. Set **Resource Owner** to `bcgov` (or your account with access to monitored repositories).
+5. Under **Repository Access**, select **Only select repositories** (or **All repositories** across monitored orgs `bcgov`, `bcgov-c`, `bcgov-nr`).
+6. Configure the minimum required permissions:
    * **Organization Permissions**:
-     * `Projects`: **Read and write** *(Required for GraphQL Project v2 management)*
+     * `Projects`: **Read and write** *(Required for GraphQL Project v2 board management)*
    * **Repository Permissions**:
      * `Issues`: **Read and write**
      * `Pull requests`: **Read and write**
      * `Metadata`: **Read-only** *(Automatically selected)*
-
-#### Fallback: Classic Personal Access Token (PAT)
-
-If Fine-Grained tokens are restricted by organization policy:
-
-| Setup Type | Required Classic Scopes | Application Context |
-| :--- | :--- | :--- |
-| **Classic PAT (Private & Public Repos)** | • `repo` (Full control of private repositories)<br>• `project` (Full control of org & user projects)<br>• `read:org` (Read org membership under `admin:org`) | Monitoring private repositories (e.g., `bcgov-c`). *Note: GitHub automatically locks child sub-scopes when `repo` is selected.* |
-| **Classic PAT (Public Repos Only)** | • `public_repo`<br>• `project`<br>• `read:org` | Monitoring public repositories only (`bcgov`). Private orgs like `bcgov-c` must be removed from `rules.yml`. |
+   * *Leave all other permissions set to **No access** (including Security events, Deployments, and Workflows).*
 
 #### Adding the Secret to GitHub Actions
 
-1. Generate your chosen token in GitHub **Settings** → **Developer Settings** → **Personal Access Tokens**.
+1. Copy the generated token string.
 2. Navigate to your repository's **Settings** → **Secrets and variables** → **Actions**.
 3. Click **New repository secret**.
 4. Set **Name** to `PROJECT_SYNC_TOKEN` and paste your token in **Secret**.

--- a/README.md
+++ b/README.md
@@ -86,25 +86,20 @@ project:
 
 The sync engine requires authentication via a repository secret named `PROJECT_SYNC_TOKEN` configured in your workflow (`.github/workflows/sync.yml`).
 
-#### Fine-Grained Personal Access Token Setup (Least Privilege)
+> **Note on Fine-Grained Tokens:** GitHub Fine-Grained PATs do not currently support `Projects` (v2) permissions under repository or account permissions. Therefore, a **Classic Personal Access Token (PAT)** is required to authenticate GitHub Projects v2 automation.
 
-1. Go to GitHub **Settings** → **Developer Settings** → **Personal Access Tokens** → [**Fine-grained tokens**](https://github.com/settings/tokens?type=beta).
-2. Click **Generate new token**.
-3. Set **Token Name** to `PROJECT_SYNC_TOKEN`.
-4. Set **Resource Owner** to `bcgov` (or your account with access to monitored repositories).
-5. Under **Repository Access**, select **Only select repositories** (or **All repositories** across monitored orgs `bcgov`, `bcgov-c`, `bcgov-nr`).
-6. Configure the minimum required permissions:
-   * **Organization Permissions**:
-     * `Projects`: **Read and write** *(Required for GraphQL Project v2 board management)*
-   * **Repository Permissions**:
-     * `Issues`: **Read and write**
-     * `Pull requests`: **Read and write**
-     * `Metadata`: **Read-only** *(Automatically selected)*
-   * *Leave all other permissions set to **No access** (including Security events, Deployments, and Workflows).*
+#### Required Classic PAT Scopes
+
+1. Go to GitHub **Settings** → **Developer Settings** → **Personal Access Tokens** → [**Tokens (classic)**](https://github.com/settings/tokens/new).
+2. Set **Note** to `PROJECT_SYNC_TOKEN`.
+3. Select the following required scopes:
+   * **`repo`** (Full control of private repositories - required to access issue and PR metadata across `bcgov` and `bcgov-c`. *Note: GitHub automatically locks child sub-scopes when `repo` is selected.*)
+   * **`project`** (Full control of organization and user projects - required for GraphQL `projectV2` access).
+   * **`read:org`** (Read org membership under `admin:org` - required for org identity resolution).
 
 #### Adding the Secret to GitHub Actions
 
-1. Copy the generated token string.
+1. Copy the generated token string (`ghp_...`).
 2. Navigate to your repository's **Settings** → **Secrets and variables** → **Actions**.
 3. Click **New repository secret**.
 4. Set **Name** to `PROJECT_SYNC_TOKEN` and paste your token in **Secret**.

--- a/README.md
+++ b/README.md
@@ -88,11 +88,10 @@ The sync engine requires authentication via a repository secret named `PROJECT_S
 
 #### Token Options & Required Scopes
 
-| Authentication Option | Required Scopes / Permissions | Best Used When |
+| Setup Type | Required Classic Scopes | Application Context |
 | :--- | :--- | :--- |
-| **Classic PAT (Private Repos)** | • `repo` (Full control of private repositories)<br>• `project` (Full control of org & user projects)<br>• `read:org` (Read org membership under `admin:org`) | Monitoring private repositories (e.g., `bcgov-c`). *Note: GitHub automatically locks child sub-scopes when `repo` is checked.* |
+| **Classic PAT (Private & Public Repos)** | • `repo` (Full control of private repositories)<br>• `project` (Full control of org & user projects)<br>• `read:org` (Read org membership under `admin:org`) | Monitoring private repositories (e.g., `bcgov-c`). *Note: GitHub automatically locks child sub-scopes when `repo` is selected.* |
 | **Classic PAT (Public Repos Only)** | • `public_repo`<br>• `project`<br>• `read:org` | Monitoring public repositories only (`bcgov`). Private orgs like `bcgov-c` must be removed from `rules.yml`. |
-| **Fine-Grained PAT / GitHub App** | • **Issues**: `Read & write`<br>• **Pull requests**: `Read & write`<br>• **Projects**: `Read & write` | Enterprise setups avoiding `security_events` entirely. Requires organization admin enablement or GitHub App installation. |
 
 #### Adding the Secret to GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,25 @@ project:
 
 The sync engine requires authentication via a repository secret named `PROJECT_SYNC_TOKEN` configured in your workflow (`.github/workflows/sync.yml`).
 
-#### Token Options & Required Scopes
+#### Recommended: Fine-Grained Personal Access Token (PAT)
+
+Fine-Grained PATs provide least-privilege security and avoid broad scopes like `security_events`, `repo:invite`, or `repo_deployment`.
+
+1. Go to GitHub **Settings** → **Developer Settings** → **Personal Access Tokens** → **Fine-grained tokens**.
+2. Click **Generate new token**.
+3. Set **Resource Owner** to `bcgov` (or your account with access to monitored repos).
+4. Under **Repository Access**, select **All repositories** (or select the specific repos in `bcgov`, `bcgov-c`, `bcgov-nr`).
+5. Configure permissions:
+   * **Organization Permissions**:
+     * `Projects`: **Read and write** *(Required for GraphQL Project v2 management)*
+   * **Repository Permissions**:
+     * `Issues`: **Read and write**
+     * `Pull requests`: **Read and write**
+     * `Metadata`: **Read-only** *(Automatically selected)*
+
+#### Fallback: Classic Personal Access Token (PAT)
+
+If Fine-Grained tokens are restricted by organization policy:
 
 | Setup Type | Required Classic Scopes | Application Context |
 | :--- | :--- | :--- |
@@ -95,7 +113,7 @@ The sync engine requires authentication via a repository secret named `PROJECT_S
 
 #### Adding the Secret to GitHub Actions
 
-1. Generate your token in GitHub **Settings** → **Developer Settings** → **Personal Access Tokens**.
+1. Generate your chosen token in GitHub **Settings** → **Developer Settings** → **Personal Access Tokens**.
 2. Navigate to your repository's **Settings** → **Secrets and variables** → **Actions**.
 3. Click **New repository secret**.
 4. Set **Name** to `PROJECT_SYNC_TOKEN` and paste your token in **Secret**.


### PR DESCRIPTION
### Summary of Changes

Adds a dedicated **Authentication & Token Setup** section to [](file:///home/derek/Repos/action-gh-project-automator/README.md) detailing:
- The required repository secret name ().
- Token options and required scope matrices (Classic PAT with private repos, Classic PAT with public repos only, and Fine-Grained/GitHub App).
- Step-by-step instructions for adding the secret in GitHub Actions settings.