### PR TITLE
refactor: purge deprecated bcgov-nr organization references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This tool transforms your GitHub Project into a self-driving productivity engine
 - **Dynamic Workflows**: Moves items between columns (e.g., `New` → `Active`) based on real-time state changes.
 - **Sprint Orchestration**: Seamlessly manages sprint assignments and rollovers.
 - **Smart Inheritance**: Propagates PR metadata (assignees, sprints, columns) to linked issues.
-- **Multi-Org Mastery**: Monitors activity across `bcgov`, `bcgov-c`, and `bcgov-nr` simultaneously.
+- **Multi-Org Mastery**: Monitors activity across `bcgov` and `bcgov-c` simultaneously.
 
 ## Automated Noise Exclusions
 
@@ -79,7 +79,6 @@ project:
   allowedOrgs:
     - bcgov
     - bcgov-c
-    - bcgov-nr
 ```
 
 ## Development & Specs

--- a/dist/index.js
+++ b/dist/index.js
@@ -41343,7 +41343,7 @@ const schema = {
         allowedOrgs: {
           type: 'array',
           items: { type: 'string' },
-          default: ['bcgov', 'bcgov-c', 'bcgov-nr'],
+          default: ['bcgov', 'bcgov-c'],
         },
       },
       oneOf: [{ required: ['id'] }, { required: ['url'] }],
@@ -46586,7 +46586,7 @@ async function run() {
     // Extract parameters
     const projectUrl =
       config.project?.url || process.env.GITHUB_PROJECT_URL || process.env.INPUT_PROJECT_URL;
-    const allowedOrgs = config.project?.allowedOrgs || ['bcgov', 'bcgov-c', 'bcgov-nr'];
+    const allowedOrgs = config.project?.allowedOrgs || ['bcgov', 'bcgov-c'];
     const maintainerRepos = config.project?.repositories || [];
     const windowHours = parseInt(process.env.UPDATE_WINDOW_HOURS || '2', 10);
 

--- a/dist/rules.yml
+++ b/dist/rules.yml
@@ -10,7 +10,6 @@ project:
   allowedOrgs: # Organizations to search for user-scoped items (author/assignee)
     - bcgov
     - bcgov-c
-    - bcgov-nr
 
 automation:
   # Rules that follow users across all repositories

--- a/rules.yml
+++ b/rules.yml
@@ -10,7 +10,6 @@ project:
   allowedOrgs: # Organizations to search for user-scoped items (author/assignee)
     - bcgov
     - bcgov-c
-    - bcgov-nr
 
 automation:
   # Rules that follow users across all repositories

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -21,7 +21,7 @@ const schema = {
         allowedOrgs: {
           type: 'array',
           items: { type: 'string' },
-          default: ['bcgov', 'bcgov-c', 'bcgov-nr'],
+          default: ['bcgov', 'bcgov-c'],
         },
       },
       oneOf: [{ required: ['id'] }, { required: ['url'] }],

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ async function run() {
     // Extract parameters
     const projectUrl =
       config.project?.url || process.env.GITHUB_PROJECT_URL || process.env.INPUT_PROJECT_URL;
-    const allowedOrgs = config.project?.allowedOrgs || ['bcgov', 'bcgov-c', 'bcgov-nr'];
+    const allowedOrgs = config.project?.allowedOrgs || ['bcgov', 'bcgov-c'];
     const maintainerRepos = config.project?.repositories || [];
     const windowHours = parseInt(process.env.UPDATE_WINDOW_HOURS || '2', 10);
 

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -10,7 +10,7 @@ test('loadBoardRules resolves config and flattens scope', () => {
   assert.ok(rules.project);
   assert.ok(rules.rules);
   assert.strictEqual(rules.monitoredUser, 'DerekRoberts');
-  assert.deepStrictEqual(rules.project.allowedOrgs, ['bcgov', 'bcgov-c', 'bcgov-nr']);
+  assert.deepStrictEqual(rules.project.allowedOrgs, ['bcgov', 'bcgov-c']);
 });
 
 test('getProjectId correctly rejects malformed project URLs', async () => {


### PR DESCRIPTION
### Summary of Changes

Purges all references to the deprecated `bcgov-nr` organization across the repository:
- Removed `bcgov-nr` from `rules.yml` allowedOrgs.
- Removed `bcgov-nr` from `README.md` documentation and configuration examples.
- Removed `bcgov-nr` from `src/config/schema.js` default schema.
- Removed `bcgov-nr` from `src/index.js` runtime fallback.
- Updated `test/engine.test.js` unit test assertions.
- Rebuilt `dist/index.js` production bundle.